### PR TITLE
Archival Notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# This repo is Archived under Pulsar-Edit. As it is now a part of [`pulsar-cooperative`](https://github.com/pulsar-cooperative/pulsar-ternjs)
+
 # atom-ternjs
 
 > JavaScript code intelligence for atom with [Tern](https://github.com/ternjs/tern).


### PR DESCRIPTION
`atom-ternjs` from the original developer was independently moved over to `pulsar-cooperative`. Seeing as how the Atom team had made 0 commits to this repo, and we only inherited it as we forked all repositories under the Atom Organization, this seems a no brainer to now archive.

I'll go ahead and merge this PR once created, and archive the repository.